### PR TITLE
hotfix: mark highlights page as dynamic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build application
         run: npm run build
         env:
-          NEXT_DISABLE_SSG: 1
+          SKIP_BUILD_STATIC_GENERATION: 1
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Build application
         run: npm run build
         env:
+          NEXT_DISABLE_SSG: 1
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          NEXT_DISABLE_SSG: 1
+          SKIP_BUILD_STATIC_GENERATION: 1
           # Use dummy values for build (actual values needed only at runtime)
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_Y2xlcms

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Skip static optimization in CI environments (no Clerk keys)
+  ...(process.env.SKIP_BUILD_STATIC_GENERATION === '1' && {
+    output: 'standalone',
+  }),
+
   // Performance optimizations
   compress: true,
   poweredByHeader: false,
@@ -68,8 +73,8 @@ const nextConfig = {
     removeConsole:
       process.env.NODE_ENV === "production"
         ? {
-            exclude: ["error", "warn"],
-          }
+          exclude: ["error", "warn"],
+        }
         : false,
   },
 

--- a/src/app/(dashboard)/highlights/page.tsx
+++ b/src/app/(dashboard)/highlights/page.tsx
@@ -5,6 +5,8 @@ import { EmptyState } from "@/components/shared/EmptyState";
 import { Bookmark } from "lucide-react";
 import { Metadata } from "next";
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: "Highlights | TalkifyDocs",
   description: "Saved Q&A pairs from your document conversations",


### PR DESCRIPTION
Fixes main branch CI failure. The /highlights page was trying to statically generate during build but requires Clerk authentication, causing builds to fail in CI environments without real Clerk keys.